### PR TITLE
Paint distribution and paint eater

### DIFF
--- a/Pigment Panic/Pigment Panic.yyp
+++ b/Pigment Panic/Pigment Panic.yyp
@@ -145,6 +145,7 @@
     {"id":{"name":"scr_grades","path":"scripts/scr_grades/scr_grades.yy",},},
     {"id":{"name":"scr_level_build","path":"scripts/scr_level_build/scr_level_build.yy",},},
     {"id":{"name":"scr_paintdrip_anim","path":"scripts/scr_paintdrip_anim/scr_paintdrip_anim.yy",},},
+    {"id":{"name":"scr_query_for_color","path":"scripts/scr_query_for_color/scr_query_for_color.yy",},},
     {"id":{"name":"scr_text","path":"scripts/scr_text/scr_text.yy",},},
     {"id":{"name":"scr_unordered_match","path":"scripts/scr_unordered_match/scr_unordered_match.yy",},},
     {"id":{"name":"scr_update_brush_color","path":"scripts/scr_update_brush_color/scr_update_brush_color.yy",},},

--- a/Pigment Panic/objects/obj_corr_brush/Alarm_0.gml
+++ b/Pigment Panic/objects/obj_corr_brush/Alarm_0.gml
@@ -3,6 +3,13 @@ hit = false
 if (target != noone) {
 	del_x = target.x - x
 	del_y = target.y - y
+	// Normalize movement vector
+	var magnitude = point_distance(0, 0, del_x, del_y)
+	if magnitude == 0 {
+		magnitude = 1	
+	}
+	del_x = del_x / magnitude
+	del_y = del_y / magnitude
 	target_x = target.x
 	target_y = target.y
 	

--- a/Pigment Panic/objects/obj_corr_brush/Alarm_0.gml
+++ b/Pigment Panic/objects/obj_corr_brush/Alarm_0.gml
@@ -1,5 +1,11 @@
-target_tile = instance_find(obj_tile_new, irandom(instance_number(obj_tile_new) - 1))
-if (target_tile != noone) {
-	del_x = target_tile.x - x
-	del_y = target_tile.y - y
+target = instance_find(obj_drop, irandom(instance_number(obj_drop) - 1))
+hit = false
+if (target != noone) {
+	del_x = target.x - x
+	del_y = target.y - y
+	target_x = target.x
+	target_y = target.y
+	
+} else {
+	alarm[0] = 10	
 }

--- a/Pigment Panic/objects/obj_corr_brush/Create_0.gml
+++ b/Pigment Panic/objects/obj_corr_brush/Create_0.gml
@@ -1,5 +1,7 @@
 target_tile = noone
 del_x = 0
 del_y = 0
+target_x = 0
+target_y = 0
 hit = false
 alarm[0] = 2

--- a/Pigment Panic/objects/obj_corr_brush/Create_0.gml
+++ b/Pigment Panic/objects/obj_corr_brush/Create_0.gml
@@ -1,7 +1,8 @@
-target_tile = noone
+target = noone
 del_x = 0
 del_y = 0
 target_x = 0
 target_y = 0
 hit = false
+speed_mult = 1000
 alarm[0] = 2

--- a/Pigment Panic/objects/obj_corr_brush/Create_0.gml
+++ b/Pigment Panic/objects/obj_corr_brush/Create_0.gml
@@ -5,4 +5,5 @@ target_x = 0
 target_y = 0
 hit = false
 speed_mult = 1000
+stolen_paints = []
 alarm[0] = 2

--- a/Pigment Panic/objects/obj_corr_brush/Step_0.gml
+++ b/Pigment Panic/objects/obj_corr_brush/Step_0.gml
@@ -5,6 +5,12 @@ if hit == false && ((target == noone) || ((abs(x - target_x) < 12) && (abs(y - t
 	del_y = 0
 	hit = true
 	if target != noone {
+		if array_length(stolen_paints) < 5 {
+			array_push(stolen_paints, target.drop_color)
+		}
+		if array_length(stolen_paints) == 5 {
+			sprite_index = spr_corrbrush_2
+		}
 		instance_destroy(target)	
 	}
 	alarm[0] = 30

--- a/Pigment Panic/objects/obj_corr_brush/Step_0.gml
+++ b/Pigment Panic/objects/obj_corr_brush/Step_0.gml
@@ -1,14 +1,11 @@
 y += 0.02 * del_y * global.time_mult
 x += 0.02 * del_x * global.time_mult
-if hit == false && target_tile != noone && (abs(x - target_tile.x) < 0.1) && (abs(y - target_tile.y) < 0.1) {
+if hit == false && (abs(x - target_x) < 0.1) && (abs(y - target_y) < 0.1) {
 	del_x = 0
-	del_y = -500
+	del_y = 0
 	hit = true
-	sprite_index = spr_corrbrush_1
-	target_tile.color_index = irandom_range(0, 25)
-	if target_tile.fill_status == -1 {
-		target_tile.fill_status = 0
-		target_tile.tile_health = 1
+	if target != noone {
+		instance_destroy(target)	
 	}
-	alarm[1] = 1200
+	alarm[0] = 30
 }

--- a/Pigment Panic/objects/obj_corr_brush/Step_0.gml
+++ b/Pigment Panic/objects/obj_corr_brush/Step_0.gml
@@ -1,6 +1,6 @@
-y += 0.02 * del_y * global.time_mult
-x += 0.02 * del_x * global.time_mult
-if hit == false && (abs(x - target_x) < 0.1) && (abs(y - target_y) < 0.1) {
+y += 0.02 * del_y * global.time_mult * speed_mult 
+x += 0.02 * del_x * global.time_mult * speed_mult
+if hit == false && ((target == noone) || ((abs(x - target_x) < 12) && (abs(y - target_y) < 12))) {
 	del_x = 0
 	del_y = 0
 	hit = true

--- a/Pigment Panic/objects/obj_corr_brush/Step_0.gml
+++ b/Pigment Panic/objects/obj_corr_brush/Step_0.gml
@@ -4,9 +4,10 @@ if hit == false && ((target == noone) || ((abs(x - target_x) < 12) && (abs(y - t
 	del_x = 0
 	del_y = 0
 	hit = true
-	if target != noone {
+	if instance_exists(target) {
+		var dc = target.drop_color
 		if array_length(stolen_paints) < 5 {
-			array_push(stolen_paints, target.drop_color)
+			array_push(stolen_paints, dc)
 		}
 		if array_length(stolen_paints) == 5 {
 			sprite_index = spr_corrbrush_2

--- a/Pigment Panic/objects/obj_corr_brush/obj_corr_brush.yy
+++ b/Pigment Panic/objects/obj_corr_brush/obj_corr_brush.yy
@@ -33,8 +33,8 @@
   "resourceVersion":"2.0",
   "solid":false,
   "spriteId":{
-    "name":"spr_corrbrush_2",
-    "path":"sprites/spr_corrbrush_2/spr_corrbrush_2.yy",
+    "name":"spr_corrbrush_1",
+    "path":"sprites/spr_corrbrush_1/spr_corrbrush_1.yy",
   },
   "spriteMaskId":null,
   "visible":true,

--- a/Pigment Panic/objects/obj_drop/Create_0.gml
+++ b/Pigment Panic/objects/obj_drop/Create_0.gml
@@ -1,7 +1,7 @@
 image_speed  = 0;
 
 // pick color/frame however you do it
-image_index  = global.drop_colors[ irandom(array_length(global.drop_colors) - 1) ];
+image_index  = scr_query_for_color();
 drop_color   = image_index;
 
 // lifetime (seconds)

--- a/Pigment Panic/objects/obj_enemymanager/Step_0.gml
+++ b/Pigment Panic/objects/obj_enemymanager/Step_0.gml
@@ -1,5 +1,7 @@
 sand_timer -= 1 * global.time_mult
-brush_timer -= 1 * global.time_mult
+if global.spawn_pen {
+	brush_timer -= 1 * global.time_mult
+}
 if (sand_timer <= 0) {
 	var random_tile = instance_find(obj_tile_new, irandom(instance_number(obj_tile_new) - 1));
 
@@ -19,4 +21,5 @@ if (brush_timer <= 0) {
 		instance_create_layer(-100, -100, "Drops", obj_corr_brush)
 	}
 	global.spawn_pen = false
+	brush_timer = 600
 }

--- a/Pigment Panic/objects/obj_enemymanager/Step_0.gml
+++ b/Pigment Panic/objects/obj_enemymanager/Step_0.gml
@@ -18,5 +18,5 @@ if (brush_timer <= 0) {
 	if global.spawn_pen {
 		instance_create_layer(-100, -100, "Drops", obj_corr_brush)
 	}
-	brush_timer = 600
+	global.spawn_pen = false
 }

--- a/Pigment Panic/objects/obj_initialize/Create_0.gml
+++ b/Pigment Panic/objects/obj_initialize/Create_0.gml
@@ -9,3 +9,7 @@ global.combo_time     = 0; // 0 until first correct paint
 global.playing = false;
 global.paused     = false;
 global.input_lock = false;
+
+global.constituents = [[0], [1], [2], [3], [4], [0, 1], [1, 2], [0, 2], [1, 2, 3], [3, 4],
+	[0, 3], [0, 4], [1, 3], [1, 4], [2, 3], [2, 4], [0, 1, 3], [0, 1, 4], [0, 2, 3], [0, 2, 4],
+	[1, 2, 3], [1, 2, 4], [0, 1, 2, 3], [0, 1, 2, 4], [3, 3, 4], [3, 4, 4]]

--- a/Pigment Panic/objects/obj_sidebar/Mouse_53.gml
+++ b/Pigment Panic/objects/obj_sidebar/Mouse_53.gml
@@ -10,6 +10,13 @@ var d = collision_point(mx, my, obj_drop, false, true);
 if (brush_type == 3) {
 	var c = collision_point(mx, my, obj_corr_brush, false, true);
 	if c != noone {
+		for (var i = 0; i < array_length(c.stolen_paints); i++) {
+			var ang = random_range(0, 360)
+			var drop = instance_create_layer(c.x + (80 * dcos(ang)), c.y + (80 * dsin(ang)),
+				"Drops", obj_drop)	
+			drop.drop_color = c.stolen_paints[i]
+			drop.image_index = c.stolen_paints[i]
+		}
 		global.spawn_pen = true
 		instance_destroy(c)
 	}

--- a/Pigment Panic/objects/obj_sidebar/Mouse_53.gml
+++ b/Pigment Panic/objects/obj_sidebar/Mouse_53.gml
@@ -7,6 +7,14 @@ var brush_type = brush.current_brush
 
 var d = collision_point(mx, my, obj_drop, false, true);
 
+if (brush_type == 3) {
+	var c = collision_point(mx, my, obj_corr_brush, false, true);
+	if c != noone {
+		global.spawn_pen = true
+		instance_destroy(c)
+	}
+}
+
 // If we're not using the knife, allow picking up paint
 if (d != noone && brush_type < 3) {
     with (d) {

--- a/Pigment Panic/rooms/rm_lv_five/rm_lv_five.yy
+++ b/Pigment Panic/rooms/rm_lv_five/rm_lv_five.yy
@@ -27,6 +27,7 @@
     {"name":"inst_1B644AFB_1","path":"rooms/rm_lv_five/rm_lv_five.yy",},
     {"name":"inst_5D009F67_1","path":"rooms/rm_lv_five/rm_lv_five.yy",},
     {"name":"inst_338A5817","path":"rooms/rm_lv_five/rm_lv_five.yy",},
+    {"name":"inst_6F6E7B99","path":"rooms/rm_lv_five/rm_lv_five.yy",},
   ],
   "isDnd":true,
   "layers":[
@@ -34,6 +35,7 @@
         {"$GMRInstance":"v4","%Name":"inst_3F9E6CBB_2","colour":4294967295,"frozen":false,"hasCreationCode":false,"ignore":false,"imageIndex":0,"imageSpeed":1.0,"inheritCode":false,"inheritedItemId":null,"inheritItemSettings":false,"isDnd":false,"name":"inst_3F9E6CBB_2","objectId":{"name":"obj_brush","path":"objects/obj_brush/obj_brush.yy",},"properties":[],"resourceType":"GMRInstance","resourceVersion":"2.0","rotation":0.0,"scaleX":1.0,"scaleY":1.0,"x":128.0,"y":-64.0,},
         {"$GMRInstance":"v4","%Name":"inst_317A18FB_1","colour":4294967295,"frozen":false,"hasCreationCode":false,"ignore":false,"imageIndex":0,"imageSpeed":1.0,"inheritCode":false,"inheritedItemId":null,"inheritItemSettings":false,"isDnd":false,"name":"inst_317A18FB_1","objectId":{"name":"obj_enemymanager","path":"objects/obj_enemymanager/obj_enemymanager.yy",},"properties":[],"resourceType":"GMRInstance","resourceVersion":"2.0","rotation":0.0,"scaleX":1.0,"scaleY":1.0,"x":192.0,"y":-64.0,},
         {"$GMRInstance":"v4","%Name":"inst_4F39CD67_1","colour":4294967295,"frozen":false,"hasCreationCode":false,"ignore":false,"imageIndex":0,"imageSpeed":1.0,"inheritCode":false,"inheritedItemId":null,"inheritItemSettings":false,"isDnd":false,"name":"inst_4F39CD67_1","objectId":{"name":"obj_level_builder","path":"objects/obj_level_builder/obj_level_builder.yy",},"properties":[],"resourceType":"GMRInstance","resourceVersion":"2.0","rotation":0.0,"scaleX":1.0,"scaleY":1.0,"x":128.0,"y":-128.0,},
+        {"$GMRInstance":"v4","%Name":"inst_6F6E7B99","colour":4294967295,"frozen":false,"hasCreationCode":false,"ignore":false,"imageIndex":0,"imageSpeed":1.0,"inheritCode":false,"inheritedItemId":null,"inheritItemSettings":false,"isDnd":false,"name":"inst_6F6E7B99","objectId":{"name":"obj_knife_button","path":"objects/obj_knife_button/obj_knife_button.yy",},"properties":[],"resourceType":"GMRInstance","resourceVersion":"2.0","rotation":0.0,"scaleX":1.0,"scaleY":1.0,"x":2048.0,"y":448.0,},
       ],"layers":[],"name":"Cursor","properties":[],"resourceType":"GMRInstanceLayer","resourceVersion":"2.0","userdefinedDepth":false,"visible":true,},
     {"$GMRInstanceLayer":"","%Name":"Drops","depth":100,"effectEnabled":true,"effectType":null,"gridX":32,"gridY":32,"hierarchyFrozen":false,"inheritLayerDepth":false,"inheritLayerSettings":false,"inheritSubLayers":true,"inheritVisibility":true,"instances":[],"layers":[],"name":"Drops","properties":[],"resourceType":"GMRInstanceLayer","resourceVersion":"2.0","userdefinedDepth":false,"visible":true,},
     {"$GMRInstanceLayer":"","%Name":"Mixer","depth":200,"effectEnabled":true,"effectType":null,"gridX":32,"gridY":32,"hierarchyFrozen":false,"inheritLayerDepth":false,"inheritLayerSettings":false,"inheritSubLayers":true,"inheritVisibility":true,"instances":[

--- a/Pigment Panic/scripts/scr_query_for_color/scr_query_for_color.gml
+++ b/Pigment Panic/scripts/scr_query_for_color/scr_query_for_color.gml
@@ -1,0 +1,30 @@
+function scr_query_for_color() {
+	var colors = [0, 0, 0, 0, 0]
+	with (obj_tile_new) {
+		if color_index == desired_color {
+			continue	
+		} else {
+			for (var i = 0; i < array_length(global.constituents[desired_color]); i++) {
+				colors[global.constituents[desired_color][i]]++	
+			}
+		}
+	}
+	var _sum = 0;
+	for (var i = 0; i < array_length(colors); i++) {
+	    _sum += colors[i];
+	}
+	var index = 0
+	var i = irandom_range(1, _sum)
+	while (index < array_length(colors)) {
+		if colors[index] == 0 {
+			index++	
+		} else {
+			i--
+			colors[index]--
+			if i == 0 {
+				return index	
+			}
+		}
+	}
+	return 0
+}

--- a/Pigment Panic/scripts/scr_query_for_color/scr_query_for_color.yy
+++ b/Pigment Panic/scripts/scr_query_for_color/scr_query_for_color.yy
@@ -1,0 +1,13 @@
+{
+  "$GMScript":"v1",
+  "%Name":"scr_query_for_color",
+  "isCompatibility":false,
+  "isDnD":false,
+  "name":"scr_query_for_color",
+  "parent":{
+    "name":"Scripts",
+    "path":"folders/Scripts.yy",
+  },
+  "resourceType":"GMScript",
+  "resourceVersion":"2.0",
+}

--- a/Pigment Panic/sprites/spr_corrbrush_1/spr_corrbrush_1.yy
+++ b/Pigment Panic/sprites/spr_corrbrush_1/spr_corrbrush_1.yy
@@ -70,7 +70,9 @@
     "timeUnits":1,
     "tracks":[
       {"$GMSpriteFramesTrack":"","builtinName":0,"events":[],"inheritsTrackColour":true,"interpolation":1,"isCreationTrack":false,"keyframes":{"$KeyframeStore<SpriteFrameKeyframe>":"","Keyframes":[
-            {"$Keyframe<SpriteFrameKeyframe>":"","Channels":{"0":{"$SpriteFrameKeyframe":"","Id":{"name":"380137cb-2cd0-4769-ac9b-aec3816ce333","path":"sprites/spr_corrbrush_1/spr_corrbrush_1.yy",},"resourceType":"SpriteFrameKeyframe","resourceVersion":"2.0",},},"Disabled":false,"id":"c3d33ef6-2c26-413b-bf60-c18a40c5450b","IsCreationKey":false,"Key":0.0,"Length":1.0,"resourceType":"Keyframe<SpriteFrameKeyframe>","resourceVersion":"2.0","Stretch":false,},
+            {"$Keyframe<SpriteFrameKeyframe>":"","Channels":{
+                "0":{"$SpriteFrameKeyframe":"","Id":{"name":"380137cb-2cd0-4769-ac9b-aec3816ce333","path":"sprites/spr_corrbrush_1/spr_corrbrush_1.yy",},"resourceType":"SpriteFrameKeyframe","resourceVersion":"2.0",},
+              },"Disabled":false,"id":"c3d33ef6-2c26-413b-bf60-c18a40c5450b","IsCreationKey":false,"Key":0.0,"Length":1.0,"resourceType":"Keyframe<SpriteFrameKeyframe>","resourceVersion":"2.0","Stretch":false,},
           ],"resourceType":"KeyframeStore<SpriteFrameKeyframe>","resourceVersion":"2.0",},"modifiers":[],"name":"frames","resourceType":"GMSpriteFramesTrack","resourceVersion":"2.0","spriteId":null,"trackColour":0,"tracks":[],"traits":0,},
     ],
     "visibleRange":null,

--- a/Pigment Panic/sprites/spr_corrbrush_2/spr_corrbrush_2.yy
+++ b/Pigment Panic/sprites/spr_corrbrush_2/spr_corrbrush_2.yy
@@ -70,7 +70,9 @@
     "timeUnits":1,
     "tracks":[
       {"$GMSpriteFramesTrack":"","builtinName":0,"events":[],"inheritsTrackColour":true,"interpolation":1,"isCreationTrack":false,"keyframes":{"$KeyframeStore<SpriteFrameKeyframe>":"","Keyframes":[
-            {"$Keyframe<SpriteFrameKeyframe>":"","Channels":{"0":{"$SpriteFrameKeyframe":"","Id":{"name":"ce53bb0c-3010-49ef-ab68-1075d41661c7","path":"sprites/spr_corrbrush_2/spr_corrbrush_2.yy",},"resourceType":"SpriteFrameKeyframe","resourceVersion":"2.0",},},"Disabled":false,"id":"6c6351ca-1ef7-42cb-aef9-13dffe22fb0a","IsCreationKey":false,"Key":0.0,"Length":1.0,"resourceType":"Keyframe<SpriteFrameKeyframe>","resourceVersion":"2.0","Stretch":false,},
+            {"$Keyframe<SpriteFrameKeyframe>":"","Channels":{
+                "0":{"$SpriteFrameKeyframe":"","Id":{"name":"ce53bb0c-3010-49ef-ab68-1075d41661c7","path":"sprites/spr_corrbrush_2/spr_corrbrush_2.yy",},"resourceType":"SpriteFrameKeyframe","resourceVersion":"2.0",},
+              },"Disabled":false,"id":"6c6351ca-1ef7-42cb-aef9-13dffe22fb0a","IsCreationKey":false,"Key":0.0,"Length":1.0,"resourceType":"Keyframe<SpriteFrameKeyframe>","resourceVersion":"2.0","Stretch":false,},
           ],"resourceType":"KeyframeStore<SpriteFrameKeyframe>","resourceVersion":"2.0",},"modifiers":[],"name":"frames","resourceType":"GMSpriteFramesTrack","resourceVersion":"2.0","spriteId":null,"trackColour":0,"tracks":[],"traits":0,},
     ],
     "visibleRange":null,


### PR DESCRIPTION
Add paint distribution so more abundantly required colors spawn more often. Also change the corrupted brush enemy to eat paint drops. Player can use the palette knife to kill the corrupted (respawns after 10 seconds) and it will drop the first (up to) 5 paints it ate.